### PR TITLE
Improve /my/ layout for mobile

### DIFF
--- a/app/my/layout.tsx
+++ b/app/my/layout.tsx
@@ -1,6 +1,14 @@
 'use client'
 
+import { Button } from '@everynews/components/ui/button'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetTrigger,
+} from '@everynews/components/ui/sheet'
 import { cn } from '@everynews/lib/utils'
+import { Menu } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
@@ -23,24 +31,48 @@ const sidebarItems = [
   },
 ]
 
+const MobileSidebar = () => (
+  <Sheet>
+    <SheetTrigger asChild>
+      <Button variant='ghost' size='icon' className='md:hidden'>
+        <Menu className='size-4' />
+        <span className='sr-only'>Open menu</span>
+      </Button>
+    </SheetTrigger>
+    <SheetContent side='left'>
+      <nav className='flex flex-col gap-2 p-4'>
+        {sidebarItems.map((item) => (
+          <SheetClose asChild key={item.href}>
+            <Link
+              href={item.href}
+              className='text-sm font-medium text-muted-foreground hover:text-foreground'
+            >
+              {item.title}
+            </Link>
+          </SheetClose>
+        ))}
+      </nav>
+    </SheetContent>
+  </Sheet>
+)
+
 const MyLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <>
-      <div className='flex'>
-        <aside className='w-64 bg-background/50 p-6'>
-          <nav className='flex flex-col gap-2'>
-            {sidebarItems.map((item) => (
-              <SidebarLink
-                key={item.href}
-                href={item.href}
-                title={item.title}
-              />
-            ))}
-          </nav>
-        </aside>
-        <main className='flex-1 py-6'>{children}</main>
+    <div className='flex'>
+      <aside className='hidden w-64 shrink-0 bg-background/50 p-6 md:block'>
+        <nav className='flex flex-col gap-2'>
+          {sidebarItems.map((item) => (
+            <SidebarLink key={item.href} href={item.href} title={item.title} />
+          ))}
+        </nav>
+      </aside>
+      <div className='flex-1'>
+        <div className='p-4 md:hidden'>
+          <MobileSidebar />
+        </div>
+        <main className='py-6'>{children}</main>
       </div>
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- add responsive sidebar in `/my` pages

## Testing
- `bun run style:check`
- `bun run db:check`


------
https://chatgpt.com/codex/tasks/task_e_684d47ce5cc48329aeb4b09994051e2f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a responsive sidebar navigation with a mobile-friendly sliding menu accessible via a hamburger button on small screens.
- **Style**
  - Sidebar is now hidden on small screens and only visible on medium and larger screens for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->