### PR TITLE
Add metadata to all Next.js pages

### DIFF
--- a/app/firefighter-mode/page.tsx
+++ b/app/firefighter-mode/page.tsx
@@ -8,6 +8,11 @@ import Link from 'next/link'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Bug fixing promise for early users.',
+  title: 'Firefighter Mode',
+}
+
 export default function FirefighterModePage() {
   return (
     <div className='container mx-auto px-6 py-20 max-w-2xl mx-auto'>

--- a/app/my/channels/page.tsx
+++ b/app/my/channels/page.tsx
@@ -20,6 +20,11 @@ import { unauthorized } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Manage where your newsletters are delivered.',
+  title: 'Channels',
+}
+
 export default async function MyChannelsPage() {
   const user = await whoami()
   if (!user) return unauthorized()

--- a/app/my/newsletters/page.tsx
+++ b/app/my/newsletters/page.tsx
@@ -24,6 +24,11 @@ import { unauthorized } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Your created newsletters.',
+  title: 'Newsletters',
+}
+
 export default async function MyNewslettersPage() {
   const user = await whoami()
   if (!user) return unauthorized()

--- a/app/my/page.tsx
+++ b/app/my/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from 'next/navigation'
 
+export const metadata = {
+  description: 'User dashboard redirect',
+  title: 'My Account',
+}
+
 export default function MyPage() {
   redirect('/my/newsletters')
 }

--- a/app/my/prompts/[id]/page.tsx
+++ b/app/my/prompts/[id]/page.tsx
@@ -7,6 +7,11 @@ import { PromptDetailPage } from './prompt-detail-page'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'View or edit your prompt configuration.',
+  title: 'Prompt Details',
+}
+
 export default async function PromptPage({
   params,
 }: {

--- a/app/my/prompts/create/page.tsx
+++ b/app/my/prompts/create/page.tsx
@@ -5,6 +5,11 @@ import { PromptCreatePage } from './prompt-create-page'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Start a new prompt for filtering content.',
+  title: 'Create Prompt',
+}
+
 export default async function CreatePromptPage() {
   const user = await whoami()
   if (!user) {

--- a/app/my/prompts/page.tsx
+++ b/app/my/prompts/page.tsx
@@ -17,6 +17,11 @@ import { redirect } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Manage your prompts for custom searches.',
+  title: 'Prompts',
+}
+
 export default async function PromptsPage() {
   const user = await whoami()
   if (!user) {

--- a/app/my/subscriptions/page.tsx
+++ b/app/my/subscriptions/page.tsx
@@ -24,6 +24,11 @@ import { unauthorized } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: "Review newsletters you're subscribed to.",
+  title: 'Subscriptions',
+}
+
 export default async function MySubscriptionsPage() {
   const user = await whoami()
   if (!user) return unauthorized()

--- a/app/newsletters/[id]/page.tsx
+++ b/app/newsletters/[id]/page.tsx
@@ -23,6 +23,11 @@ import { notFound } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Recent stories from this newsletter.',
+  title: 'Newsletter Stories',
+}
+
 export default async function NewsletterStoriesPage({
   params,
   searchParams,

--- a/app/newsletters/page.tsx
+++ b/app/newsletters/page.tsx
@@ -26,6 +26,11 @@ import Link from 'next/link'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Browse public newsletters.',
+  title: 'Newsletters',
+}
+
 export default async function NewslettersPage() {
   // Get current user and their data
   const user = await whoami()

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { siteConfig } from '@everynews/app/site-config'
 import { Badge } from '@everynews/components/ui/badge'
 import { Card, CardContent, CardHeader } from '@everynews/components/ui/card'
 import { db } from '@everynews/database'
@@ -16,6 +17,11 @@ import {
 import Link from 'next/link'
 
 export const dynamic = 'force-dynamic'
+
+export const metadata = {
+  description: siteConfig.description,
+  title: siteConfig.name,
+}
 
 export default async function Page() {
   // Get recent stories from all public newsletters

--- a/app/stories/[id]/page.tsx
+++ b/app/stories/[id]/page.tsx
@@ -11,6 +11,11 @@ import { notFound } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
+export const metadata = {
+  description: 'Full story from a subscribed newsletter.',
+  title: 'Story Details',
+}
+
 export default async function StoryPage({
   params,
 }: {

--- a/app/verify/channel/[token]/page.tsx
+++ b/app/verify/channel/[token]/page.tsx
@@ -3,6 +3,11 @@ import { Button } from '@everynews/components/ui/button'
 import { CheckCircle, XCircle } from 'lucide-react'
 import Link from 'next/link'
 
+export const metadata = {
+  description: 'Confirm your delivery channel.',
+  title: 'Verify Channel',
+}
+
 export default async function VerifyChannelPage({
   params,
 }: {


### PR DESCRIPTION
## Summary
- provide per-page metadata objects across the app

## Testing
- `bun run style:check`
- `bun run db:check`

------
https://chatgpt.com/codex/tasks/task_e_684d4a677a608329928438cecbbd185f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added descriptive metadata (title and description) to multiple pages, improving page information for users and enhancing SEO and sharing previews. No changes to page content or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->