### PR TITLE
Refactor form layout into reusable component

### DIFF
--- a/components/channel-dialog.tsx
+++ b/components/channel-dialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { api } from '@everynews/app/api'
+import { FormFieldRow } from '@everynews/components/form-field-row'
 import { Button } from '@everynews/components/ui/button'
 import {
   Dialog,
@@ -13,8 +14,6 @@ import {
   Form,
   FormControl,
   FormField,
-  FormItem,
-  FormLabel,
   FormMessage,
 } from '@everynews/components/ui/form'
 import { Input } from '@everynews/components/ui/input'
@@ -175,19 +174,15 @@ export const ChannelDialog = ({
               control={form.control}
               name='name'
               render={({ field }) => (
-                <FormItem className='md:flex md:items-center md:justify-between'>
-                  <div className='md:w-1/2'>
-                    <FormLabel className='text-md'>
-                      What should we call this channel?
-                    </FormLabel>
-                  </div>
-                  <div className='md:w-1/2'>
-                    <FormControl>
-                      <Input placeholder='My Email Channel' {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </div>
-                </FormItem>
+                <FormFieldRow
+                  label='What should we call this channel?'
+                  labelWidth='1/2'
+                >
+                  <FormControl>
+                    <Input placeholder='My Email Channel' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormFieldRow>
               )}
             />
 
@@ -197,17 +192,12 @@ export const ChannelDialog = ({
               control={form.control}
               name='config.destination'
               render={({ field }) => (
-                <FormItem className='md:flex md:items-center md:justify-between'>
-                  <div className='md:w-1/2'>
-                    <FormLabel className='text-md'>Email Address</FormLabel>
-                  </div>
-                  <div className='md:w-1/2'>
-                    <FormControl>
-                      <Input placeholder='you@example.com' {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </div>
-                </FormItem>
+                <FormFieldRow label='Email Address' labelWidth='1/2'>
+                  <FormControl>
+                    <Input placeholder='you@example.com' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormFieldRow>
               )}
             />
 

--- a/components/form-field-row.tsx
+++ b/components/form-field-row.tsx
@@ -1,0 +1,26 @@
+import { FormItem, FormLabel } from '@everynews/components/ui/form'
+import { cn } from '@everynews/lib/utils'
+import type { ReactNode } from 'react'
+
+interface FormFieldRowProps {
+  label: ReactNode
+  children: ReactNode
+  labelWidth?: '1/2' | '1/3' | '1/4'
+  className?: string
+}
+
+export const FormFieldRow = ({
+  label,
+  children,
+  labelWidth = '1/3',
+  className,
+}: FormFieldRowProps) => (
+  <FormItem
+    className={cn('md:flex md:items-center md:justify-between', className)}
+  >
+    <div className={cn(`md:w-${labelWidth}`)}>
+      <FormLabel className='text-md'>{label}</FormLabel>
+    </div>
+    <div className='md:flex-1'>{children}</div>
+  </FormItem>
+)


### PR DESCRIPTION
## Summary
- add a new `FormFieldRow` component for consistent form layout
- refactor `ChannelDialog` to use the new component

## Testing
- `bun run tidy`

------
https://chatgpt.com/codex/tasks/task_e_684e74d927ac8329ae82982fa379dcd7