### PR TITLE
Add threshold and irrelevant fields

### DIFF
--- a/app/my/alerts/[id]/alert-edit-page.tsx
+++ b/app/my/alerts/[id]/alert-edit-page.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from '@everynews/components/ui/select'
 import { Separator } from '@everynews/components/ui/separator'
+import { Slider } from '@everynews/components/ui/slider'
 import { Switch } from '@everynews/components/ui/switch'
 import { Tabs, TabsList, TabsTrigger } from '@everynews/components/ui/tabs'
 import { Textarea } from '@everynews/components/ui/textarea'
@@ -110,6 +111,7 @@ export const AlertEditPage = ({
       name: alert.name,
       promptId: alert.promptId,
       strategy: alert.strategy,
+      threshold: alert.threshold,
       wait: alert.wait,
     },
     resolver: zodResolver(AlertDtoSchema),
@@ -129,6 +131,7 @@ export const AlertEditPage = ({
           values.strategy.provider === 'exa'
             ? { provider: 'exa', query: values.strategy.query || '' }
             : { provider: 'hnbest' },
+        threshold: values.threshold,
         wait: values.wait,
       }
 
@@ -168,6 +171,7 @@ export const AlertEditPage = ({
           values.strategy.provider === 'exa'
             ? { provider: 'exa', query: values.strategy.query || '' }
             : { provider: 'hnbest' },
+        threshold: values.threshold,
         wait: values.wait,
       }
 
@@ -339,6 +343,26 @@ export const AlertEditPage = ({
                           : 'Edit Prompt'}
                       </Button>
                     </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='threshold'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Relevance Threshold ({field.value}%)</FormLabel>
+                    <FormControl>
+                      <Slider
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={[field.value]}
+                        onValueChange={(val) => field.onChange(val[0])}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/app/my/alerts/create/alert-create-page.tsx
+++ b/app/my/alerts/create/alert-create-page.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from '@everynews/components/ui/select'
 import { Separator } from '@everynews/components/ui/separator'
+import { Slider } from '@everynews/components/ui/slider'
 import { Switch } from '@everynews/components/ui/switch'
 import { Tabs, TabsList, TabsTrigger } from '@everynews/components/ui/tabs'
 import { Textarea } from '@everynews/components/ui/textarea'
@@ -85,6 +86,7 @@ export const AlertCreatePage = ({ prompts }: { prompts: Prompt[] }) => {
       name: humanId({ capitalize: false, separator: '-' }),
       promptId: null,
       strategy: { provider: 'hnbest' },
+      threshold: 70,
       wait: { type: 'count', value: 10 },
     },
     resolver: zodResolver(AlertDtoSchema),
@@ -104,6 +106,7 @@ export const AlertCreatePage = ({ prompts }: { prompts: Prompt[] }) => {
           values.strategy.provider === 'exa'
             ? { provider: 'exa', query: values.strategy.query || '' }
             : { provider: 'hnbest' },
+        threshold: values.threshold,
         wait: values.wait,
       }
 
@@ -140,6 +143,7 @@ export const AlertCreatePage = ({ prompts }: { prompts: Prompt[] }) => {
           values.strategy.provider === 'exa'
             ? { provider: 'exa', query: values.strategy.query || '' }
             : { provider: 'hnbest' },
+        threshold: values.threshold,
         wait: values.wait,
       }
 
@@ -311,6 +315,26 @@ export const AlertCreatePage = ({ prompts }: { prompts: Prompt[] }) => {
                           : 'Edit Prompt'}
                       </Button>
                     </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name='threshold'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Relevance Threshold ({field.value}%)</FormLabel>
+                    <FormControl>
+                      <Slider
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={[field.value]}
+                        onValueChange={(val) => field.onChange(val[0])}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
+        "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
@@ -361,6 +362,8 @@
     "@radix-ui/react-select": ["@radix-ui/react-select@2.2.5", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.2", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.7", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA=="],
 
     "@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA=="],
+
+    "@radix-ui/react-slider": ["@radix-ui/react-slider@1.3.5", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.2", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-use-size": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-rkfe2pU2NBAYfGaxa3Mqosi7VZEWX5CxKaanRv0vZd4Zhl9fvQrg0VM93dv3xGLGfrHuoTRF3JXH8nb9g+B3fw=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/components/alert-dialog.tsx
+++ b/components/alert-dialog.tsx
@@ -92,6 +92,7 @@ export const AlertDialog = ({
     name: humanId({ capitalize: false, separator: '-' }),
     promptId: null,
     strategy: { provider: 'hnbest' },
+    threshold: 70,
     wait: { type: 'count', value: 10 },
   }
 
@@ -107,6 +108,7 @@ export const AlertDialog = ({
             name: original?.name || '',
             promptId: original?.promptId || null,
             strategy: original?.strategy || { provider: 'hnbest' },
+            threshold: original?.threshold ?? 70,
             wait: original?.wait || { type: 'count', value: 10 },
           },
     resolver: zodResolver(AlertDtoSchema),
@@ -126,6 +128,7 @@ export const AlertDialog = ({
           values.strategy.provider === 'exa'
             ? { provider: 'exa', query: values.strategy.query || '' }
             : { provider: 'hnbest' },
+        threshold: values.threshold,
         wait: values.wait,
       }
       let res: Response

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { cn } from '@everynews/lib/utils'
+import * as SliderPrimitive from '@radix-ui/react-slider'
+import * as React from 'react'
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn(
+      'relative flex w-full touch-none select-none items-center',
+      className,
+    )}
+    {...props}
+  >
+    <SliderPrimitive.Track className='relative h-1 w-full grow overflow-hidden rounded-full bg-secondary'>
+      <SliderPrimitive.Range className='absolute h-full bg-primary' />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className='block h-4 w-4 rounded-full border-2 border-primary bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50' />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }

--- a/drizzle/0001_typical_madrox.sql
+++ b/drizzle/0001_typical_madrox.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "alert" ADD COLUMN "threshold" integer DEFAULT 70 NOT NULL;--> statement-breakpoint
+ALTER TABLE "stories" ADD COLUMN "irrelevant" boolean;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,927 @@
+{
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "dialect": "postgresql",
+  "enums": {},
+  "id": "9313bf6e-a4c5-47ca-aad5-c9415d8e13c6",
+  "policies": {},
+  "prevId": "660a4d81-733a-4111-a200-3f18f36d2da7",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.accounts": {
+      "checkConstraints": {},
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "account_id": {
+          "name": "account_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "id_token": {
+          "name": "id_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "password": {
+          "name": "password",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "scope": {
+          "name": "scope",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "accounts_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "accounts",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "accounts",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.alert": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "description": {
+          "name": "description",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "is_public": {
+          "default": true,
+          "name": "is_public",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "language": {
+          "default": "'en'",
+          "name": "language",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "last_run": {
+          "default": "now()",
+          "name": "last_run",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "next_run": {
+          "default": "now()",
+          "name": "next_run",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "strategy": {
+          "name": "strategy",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "threshold": {
+          "default": 70,
+          "name": "threshold",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "wait": {
+          "name": "wait",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "json"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "alert_prompt_id_prompt_id_fk": {
+          "columnsFrom": ["prompt_id"],
+          "columnsTo": ["id"],
+          "name": "alert_prompt_id_prompt_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "alert",
+          "tableTo": "prompt"
+        },
+        "alert_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "alert_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "alert",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "alert",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.channel_verifications": {
+      "checkConstraints": {},
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "used": {
+          "default": false,
+          "name": "used",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "channel_verifications_channel_id_channels_id_fk": {
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "name": "channel_verifications_channel_id_channels_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "channel_verifications",
+          "tableTo": "channels"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "channel_verifications",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "channel_verifications_token_unique": {
+          "columns": ["token"],
+          "name": "channel_verifications_token_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.channels": {
+      "checkConstraints": {},
+      "columns": {
+        "config": {
+          "name": "config",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "type": {
+          "name": "type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "verified": {
+          "default": false,
+          "name": "verified",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "channels_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "channels_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "channels",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "channels",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.contents": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "html_blob_url": {
+          "name": "html_blob_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "markdown_blob_url": {
+          "name": "markdown_blob_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "title": {
+          "name": "title",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "contents",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "contents_url_unique": {
+          "columns": ["url"],
+          "name": "contents_url_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.prompt": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "prompt_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "prompt_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "prompt",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "prompt",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.sessions": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "sessions_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "sessions",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "sessions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "columns": ["token"],
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.stories": {
+      "checkConstraints": {},
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "content_id": {
+          "name": "content_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "irrelevant": {
+          "name": "irrelevant",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "key_findings": {
+          "name": "key_findings",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "language_code": {
+          "default": "'en'",
+          "name": "language_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "title": {
+          "name": "title",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "stories_alert_id_alert_id_fk": {
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "name": "stories_alert_id_alert_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "stories",
+          "tableTo": "alert"
+        },
+        "stories_content_id_contents_id_fk": {
+          "columnsFrom": ["content_id"],
+          "columnsTo": ["id"],
+          "name": "stories_content_id_contents_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "stories",
+          "tableTo": "contents"
+        },
+        "stories_prompt_id_prompt_id_fk": {
+          "columnsFrom": ["prompt_id"],
+          "columnsTo": ["id"],
+          "name": "stories_prompt_id_prompt_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "stories",
+          "tableTo": "prompt"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "stories",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "stories_url_prompt_id_unique": {
+          "columns": ["url", "prompt_id"],
+          "name": "stories_url_prompt_id_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "subscriptions_alert_id_alert_id_fk": {
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "name": "subscriptions_alert_id_alert_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "subscriptions",
+          "tableTo": "alert"
+        },
+        "subscriptions_channel_id_channels_id_fk": {
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "name": "subscriptions_channel_id_channels_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "subscriptions",
+          "tableTo": "channels"
+        },
+        "subscriptions_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "subscriptions_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "subscriptions",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "email": {
+          "name": "email",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "image": {
+          "name": "image",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "phone_number_verified": {
+          "name": "phone_number_verified",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "users",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "columns": ["email"],
+          "name": "users_email_unique",
+          "nullsNotDistinct": false
+        },
+        "users_phone_number_unique": {
+          "columns": ["phone_number"],
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.verifications": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "identifier": {
+          "name": "identifier",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "value": {
+          "name": "value",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "verifications",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -7,6 +7,13 @@
       "tag": "0000_woozy_kate_bishop",
       "version": "7",
       "when": 1749993884812
+    },
+    {
+      "breakpoints": true,
+      "idx": 1,
+      "tag": "0001_typical_madrox",
+      "version": "7",
+      "when": 1750068554880
     }
   ],
   "version": "7"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
+    "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/schema/alert.ts
+++ b/schema/alert.ts
@@ -1,7 +1,14 @@
 import { z } from 'zod'
 import 'zod-openapi/extend'
 import { nanoid } from '@everynews/lib/id'
-import { boolean, json, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+import {
+  boolean,
+  integer,
+  json,
+  pgTable,
+  text,
+  timestamp,
+} from 'drizzle-orm/pg-core'
 import { LANGUAGE_CODES, LanguageSchema } from './language'
 import { prompt } from './prompt'
 import { strategySchema } from './strategy'
@@ -22,6 +29,7 @@ export const alert = pgTable('alert', {
     onDelete: 'set null',
   }),
   strategy: json('strategy').notNull(),
+  threshold: integer('threshold').notNull().default(70),
   updatedAt: timestamp('updated_at').notNull().defaultNow(),
   userId: text('user_id')
     .notNull()
@@ -48,6 +56,7 @@ export const AlertSchema = z
     nextRun: z.coerce.date().nullable().openapi({ example: new Date() }),
     promptId: z.coerce.string().nullable().openapi({ example: '123' }),
     strategy: strategySchema,
+    threshold: z.coerce.number().int().min(0).max(100).openapi({ example: 70 }),
     updatedAt: z.coerce.date().openapi({ example: new Date() }),
     userId: z.coerce.string().openapi({ example: '123' }),
     wait: WaitSchema,

--- a/schema/story.ts
+++ b/schema/story.ts
@@ -1,6 +1,13 @@
 import 'zod-openapi/extend'
 import { nanoid } from '@everynews/lib/id'
-import { json, pgTable, text, timestamp, unique } from 'drizzle-orm/pg-core'
+import {
+  boolean,
+  json,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+} from 'drizzle-orm/pg-core'
 import { z } from 'zod'
 import { alert } from './alert'
 import { prompt } from './prompt'
@@ -19,6 +26,7 @@ export const stories = pgTable(
       .references(() => contents.id, { onDelete: 'cascade' }),
     createdAt: timestamp('created_at').notNull().defaultNow(),
     id: text('id').primaryKey().$defaultFn(nanoid),
+    irrelevant: boolean('irrelevant'),
     keyFindings: json('key_findings'),
     languageCode: text('language_code', { enum: LANGUAGE_CODES })
       .notNull()
@@ -43,6 +51,7 @@ export const StorySchema = z
     contentId: z.coerce.string().openapi({ example: 'content123' }),
     createdAt: z.coerce.date().openapi({ example: new Date() }),
     id: z.coerce.string().openapi({ example: '123' }),
+    irrelevant: z.boolean().nullable().openapi({ example: false }),
     keyFindings: z
       .array(z.string())
       .nullable()
@@ -62,6 +71,7 @@ export const StoryDtoSchema = StorySchema.omit({
   contentId: true,
   createdAt: true,
   id: true,
+  irrelevant: true,
   promptId: true,
   updatedAt: true,
 }).openapi({ ref: 'StoryDtoSchema' })

--- a/server/alerts/index.ts
+++ b/server/alerts/index.ts
@@ -119,6 +119,7 @@ export const AlertRouter = new Hono<WithAuth>()
         language,
         promptId,
         active,
+        threshold,
       } = await c.req.json()
       const user = c.get('user')
       if (!user) {
@@ -141,6 +142,7 @@ export const AlertRouter = new Hono<WithAuth>()
           name,
           promptId,
           strategy,
+          threshold,
           userId: user.id,
           wait,
         })

--- a/server/drill/index.ts
+++ b/server/drill/index.ts
@@ -54,6 +54,7 @@ export const DrillRouter = new Hono<WithAuth>().use(authMiddleware).post(
       nextRun: null,
       promptId: alertData.promptId,
       strategy: alertData.strategy,
+      threshold: alertData.threshold,
       updatedAt: new Date(),
       userId: user.id,
       wait: alertData.wait,

--- a/server/subroutines/aspirant.ts
+++ b/server/subroutines/aspirant.ts
@@ -76,6 +76,7 @@ export const aspirant = async (alert: Alert): Promise<Story[]> => {
           contentId: summary.contentId,
           createdAt: new Date(),
           id: nanoid(),
+          irrelevant: null,
           keyFindings: summary.keyFindings,
           languageCode: summary.languageCode,
           promptId: summary.promptId,

--- a/server/subroutines/sage.ts
+++ b/server/subroutines/sage.ts
@@ -89,6 +89,7 @@ export const summarizeContent = async ({
     return {
       alertId: news.id,
       contentId: content.id,
+      irrelevant: false,
       keyFindings,
       languageCode,
       promptId: news.promptId,


### PR DESCRIPTION
## Summary
- add a Slider component
- add `threshold` column to alerts and `irrelevant` column to stories
- expose new fields in API endpoints
- support threshold slider when creating and editing alerts
- update drill and aspirant subroutines for new schema
- generate new migration

## Testing
- `bun run tidy`

------
https://chatgpt.com/codex/tasks/task_e_684feb4705b4832981f8522494ed5366