### PR TITLE
Refactor story handling to incorporate user and system relevance flags

### DIFF
--- a/app/alerts/[id]/page.tsx
+++ b/app/alerts/[id]/page.tsx
@@ -104,7 +104,14 @@ export default async function AlertStoriesPage({
       contents,
       and(eq(stories.contentId, contents.id), isNull(contents.deletedAt)),
     )
-    .where(and(eq(stories.alertId, id), isNull(stories.deletedAt)))
+    .where(
+      and(
+        eq(stories.alertId, id),
+        isNull(stories.deletedAt),
+        eq(stories.userMarkedIrrelevant, false),
+        eq(stories.systemMarkedIrrelevant, false),
+      ),
+    )
     .orderBy(desc(stories.createdAt))
     .limit(itemsPerPage)
     .offset(offset)
@@ -113,7 +120,14 @@ export default async function AlertStoriesPage({
   const totalStories = await db
     .select({ count: stories.id })
     .from(stories)
-    .where(and(eq(stories.alertId, id), isNull(stories.deletedAt)))
+    .where(
+      and(
+        eq(stories.alertId, id),
+        isNull(stories.deletedAt),
+        eq(stories.userMarkedIrrelevant, false),
+        eq(stories.systemMarkedIrrelevant, false),
+      ),
+    )
 
   const totalPages = Math.ceil(totalStories.length / itemsPerPage)
   const hasNextPage = currentPage < totalPages

--- a/drizzle/0002_nifty_lenny_balinger.sql
+++ b/drizzle/0002_nifty_lenny_balinger.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "stories" RENAME COLUMN "irrelevant" TO "user_marked_irrelevant";--> statement-breakpoint
+ALTER TABLE "stories" ADD COLUMN "system_marked_irrelevant" boolean DEFAULT false;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,999 @@
+{
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "dialect": "postgresql",
+  "enums": {},
+  "id": "f2314faf-334a-456f-8196-99592f63d2da",
+  "policies": {},
+  "prevId": "e12aa756-8411-48c9-93ca-ccf3744f2c62",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.accounts": {
+      "checkConstraints": {},
+      "columns": {
+        "access_token": {
+          "name": "access_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "account_id": {
+          "name": "account_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "id_token": {
+          "name": "id_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "password": {
+          "name": "password",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "scope": {
+          "name": "scope",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "accounts_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "accounts",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "accounts",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.alert": {
+      "checkConstraints": {},
+      "columns": {
+        "active": {
+          "default": true,
+          "name": "active",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "description": {
+          "name": "description",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "is_public": {
+          "default": true,
+          "name": "is_public",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "language": {
+          "default": "'en'",
+          "name": "language",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "last_run": {
+          "default": "now()",
+          "name": "last_run",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "next_run": {
+          "default": "now()",
+          "name": "next_run",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "strategy": {
+          "name": "strategy",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "threshold": {
+          "default": 70,
+          "name": "threshold",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "wait": {
+          "name": "wait",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "json"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "alert_prompt_id_prompt_id_fk": {
+          "columnsFrom": ["prompt_id"],
+          "columnsTo": ["id"],
+          "name": "alert_prompt_id_prompt_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "alert",
+          "tableTo": "prompt"
+        },
+        "alert_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "alert_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "alert",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {
+        "alert_user_id_deleted_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "user_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "deleted_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "alert_user_id_deleted_at_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "alert",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.channel_verifications": {
+      "checkConstraints": {},
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "used": {
+          "default": false,
+          "name": "used",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "channel_verifications_channel_id_channels_id_fk": {
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "name": "channel_verifications_channel_id_channels_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "channel_verifications",
+          "tableTo": "channels"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "channel_verifications",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "channel_verifications_token_unique": {
+          "columns": ["token"],
+          "name": "channel_verifications_token_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.channels": {
+      "checkConstraints": {},
+      "columns": {
+        "config": {
+          "name": "config",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "type": {
+          "name": "type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "verified": {
+          "default": false,
+          "name": "verified",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "channels_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "channels_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "channels",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "channels",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.contents": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "html_blob_url": {
+          "name": "html_blob_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "markdown_blob_url": {
+          "name": "markdown_blob_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "title": {
+          "name": "title",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "contents",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "contents_url_unique": {
+          "columns": ["url"],
+          "name": "contents_url_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.prompt": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "prompt_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "prompt_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "prompt",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "prompt",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.sessions": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "token": {
+          "name": "token",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "sessions_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "sessions",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "sessions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "columns": ["token"],
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.stories": {
+      "checkConstraints": {},
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "content_id": {
+          "name": "content_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "key_findings": {
+          "name": "key_findings",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "json"
+        },
+        "language_code": {
+          "default": "'en'",
+          "name": "language_code",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "system_marked_irrelevant": {
+          "default": false,
+          "name": "system_marked_irrelevant",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "title": {
+          "name": "title",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "url": {
+          "name": "url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "user_marked_irrelevant": {
+          "default": false,
+          "name": "user_marked_irrelevant",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "stories_alert_id_alert_id_fk": {
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "name": "stories_alert_id_alert_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "stories",
+          "tableTo": "alert"
+        },
+        "stories_content_id_contents_id_fk": {
+          "columnsFrom": ["content_id"],
+          "columnsTo": ["id"],
+          "name": "stories_content_id_contents_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "stories",
+          "tableTo": "contents"
+        },
+        "stories_prompt_id_prompt_id_fk": {
+          "columnsFrom": ["prompt_id"],
+          "columnsTo": ["id"],
+          "name": "stories_prompt_id_prompt_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "stories",
+          "tableTo": "prompt"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "stories",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "stories_url_prompt_hash_unique": {
+          "columns": ["url", "prompt_hash"],
+          "name": "stories_url_prompt_hash_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.subscriptions": {
+      "checkConstraints": {},
+      "columns": {
+        "alert_id": {
+          "name": "alert_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "user_id": {
+          "name": "user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "subscriptions_alert_id_alert_id_fk": {
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "name": "subscriptions_alert_id_alert_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "subscriptions",
+          "tableTo": "alert"
+        },
+        "subscriptions_channel_id_channels_id_fk": {
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "name": "subscriptions_channel_id_channels_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "subscriptions",
+          "tableTo": "channels"
+        },
+        "subscriptions_user_id_users_id_fk": {
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "name": "subscriptions_user_id_users_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "subscriptions",
+          "tableTo": "users"
+        }
+      },
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "subscriptions",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "email": {
+          "name": "email",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "image": {
+          "name": "image",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "phone_number_verified": {
+          "name": "phone_number_verified",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "boolean"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "users",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "columns": ["email"],
+          "name": "users_email_unique",
+          "nullsNotDistinct": false
+        },
+        "users_phone_number_unique": {
+          "columns": ["phone_number"],
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.verifications": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "id": {
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "text"
+        },
+        "identifier": {
+          "name": "identifier",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp"
+        },
+        "value": {
+          "name": "value",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {},
+      "isRLSEnabled": false,
+      "name": "verifications",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -14,6 +14,13 @@
       "tag": "0001_furry_storm",
       "version": "7",
       "when": 1750209866267
+    },
+    {
+      "breakpoints": true,
+      "idx": 2,
+      "tag": "0002_nifty_lenny_balinger",
+      "version": "7",
+      "when": 1750252472582
     }
   ],
   "version": "7"

--- a/schema/story.ts
+++ b/schema/story.ts
@@ -27,7 +27,6 @@ export const stories = pgTable(
     createdAt: timestamp('created_at').notNull().defaultNow(),
     deletedAt: timestamp('deleted_at'),
     id: text('id').primaryKey().$defaultFn(nanoid),
-    irrelevant: boolean('irrelevant'),
     keyFindings: json('key_findings'),
     languageCode: text('language_code', { enum: LANGUAGE_CODES })
       .notNull()
@@ -36,9 +35,11 @@ export const stories = pgTable(
     promptId: text('prompt_id').references(() => prompt.id, {
       onDelete: 'set null',
     }),
+    systemMarkedIrrelevant: boolean('system_marked_irrelevant').default(false),
     title: text('title').notNull(),
     updatedAt: timestamp('updated_at').notNull().defaultNow(),
     url: text('url').notNull(),
+    userMarkedIrrelevant: boolean('user_marked_irrelevant').default(false),
   },
   (table) => ({
     // Unique constraint on URL + promptHash combination
@@ -54,7 +55,6 @@ export const StorySchema = z
     createdAt: z.coerce.date().openapi({ example: new Date() }),
     deletedAt: z.date().nullable().openapi({ example: null }),
     id: z.coerce.string().openapi({ example: '123' }),
-    irrelevant: z.boolean().nullable().openapi({ example: false }),
     keyFindings: z
       .array(z.string())
       .nullable()
@@ -64,9 +64,11 @@ export const StorySchema = z
     languageCode: LanguageSchema,
     promptHash: z.string().openapi({ example: 'hash123' }),
     promptId: z.coerce.string().nullable().openapi({ example: 'prompt123' }),
+    systemMarkedIrrelevant: z.boolean().nullable().openapi({ example: false }),
     title: z.string().openapi({ example: 'Title' }),
     updatedAt: z.coerce.date().openapi({ example: new Date() }),
     url: z.string().openapi({ example: 'https://example.com' }),
+    userMarkedIrrelevant: z.boolean().nullable().openapi({ example: false }),
   })
   .openapi({ ref: 'StorySchema' })
 
@@ -76,9 +78,10 @@ export const StoryDtoSchema = StorySchema.omit({
   createdAt: true,
   deletedAt: true,
   id: true,
-  irrelevant: true,
   promptId: true,
+  systemMarkedIrrelevant: true,
   updatedAt: true,
+  userMarkedIrrelevant: true,
 }).openapi({ ref: 'StoryDtoSchema' })
 
 export type Story = z.infer<typeof StorySchema>

--- a/server/cron/index.ts
+++ b/server/cron/index.ts
@@ -207,8 +207,12 @@ export const CronRouter = new Hono().get(
         const contents: Content[] = await reaper(urls)
         const stories = await sage({ contents, news: item })
 
-        // Filter stories to only include those created since lastRun
+        // Filter stories to only include those created since lastRun and not marked as irrelevant
         const filteredStories = stories.filter((story) => {
+          // Filter out both user-marked and system-marked irrelevant stories
+          if (story.userMarkedIrrelevant || story.systemMarkedIrrelevant) {
+            return false
+          }
           if (!item.lastRun) return true // If no lastRun, include all stories
           return story.createdAt > item.lastRun
         })

--- a/server/subroutines/aspirant.ts
+++ b/server/subroutines/aspirant.ts
@@ -78,14 +78,15 @@ export const aspirant = async (alert: Alert): Promise<Story[]> => {
           createdAt: now,
           deletedAt: null,
           id: nanoid(),
-          irrelevant: null,
           keyFindings: summary.keyFindings,
           languageCode: summary.languageCode,
           promptHash: summary.promptHash,
           promptId: summary.promptId,
+          systemMarkedIrrelevant: null,
           title: summary.title,
           updatedAt: now,
           url: summary.url,
+          userMarkedIrrelevant: null,
         })
       }
     }

--- a/server/subroutines/curator.ts
+++ b/server/subroutines/curator.ts
@@ -26,20 +26,26 @@ export const curator = async (alert: Alert): Promise<string[]> => {
     const curator: Curator = curators[alert.strategy.provider]
     const urls = await curator(alert)
 
+    // Deduplicate URLs to prevent processing the same URL multiple times
+    const uniqueUrls = [...new Set(urls)]
+    const duplicatesRemoved = urls.length - uniqueUrls.length
+
     await track({
       channel: 'curator',
-      event: `Curated "${alert.name}", Found ${urls.length} URLs`,
+      event: `Curated "${alert.name}", Found ${uniqueUrls.length} unique URLs${duplicatesRemoved > 0 ? ` (${duplicatesRemoved} duplicates removed)` : ''}`,
       icon: '✅',
       tags: {
         alert_id: alert.id,
         alert_name: alert.name,
+        duplicates_removed: duplicatesRemoved,
         provider: alert.strategy.provider,
         type: 'info',
+        unique_urls: uniqueUrls.length,
         urls_found: urls.length,
       },
     })
 
-    return urls
+    return uniqueUrls
   } catch (error) {
     await track({
       channel: 'curator',


### PR DESCRIPTION
- Updated the `stories` table schema to replace the `irrelevant` column with `user_marked_irrelevant` and `system_marked_irrelevant` columns.
- Modified the logic in the `AlertStoriesPage` to filter out stories marked as irrelevant by either users or the system.
- Adjusted the story creation and summarization processes to set the new relevance flags appropriately.
- Enhanced the `sage` function to track system-marked irrelevant content and handle race conditions during story insertion.