### PR TITLE
Update alert email header

### DIFF
--- a/cron/process-alert.ts
+++ b/cron/process-alert.ts
@@ -90,6 +90,8 @@ export const processAlert = async (item: Alert) => {
       where: eq(subscriptions.alertId, item.id),
     })
 
+    const readerCount = subscribers.length
+
     for (const subscriber of subscribers) {
       const user = await db.query.users.findFirst({
         where: eq(users.id, subscriber.userId),
@@ -97,8 +99,11 @@ export const processAlert = async (item: Alert) => {
       await herald({
         alertName: item.name,
         channelId: subscriber.channelId,
+        readerCount,
         stories: filteredStories,
+        strategy: item.strategy,
         user,
+        wait: item.wait,
       })
     }
   } else {

--- a/emails/alert.tsx
+++ b/emails/alert.tsx
@@ -1,4 +1,4 @@
-import type { Story } from '@everynews/schema'
+import type { Story, Strategy, WaitSchema } from '@everynews/schema'
 import {
   Body,
   Container,
@@ -8,9 +8,25 @@ import {
   Preview,
   Section,
   Tailwind,
+  Text,
 } from '@react-email/components'
+import type { z } from 'zod'
 
-export const Alert = ({ stories }: { stories: Story[] }) => {
+type Wait = z.infer<typeof WaitSchema>
+
+export const Alert = ({
+  alertName,
+  readerCount,
+  stories,
+  strategy,
+  wait,
+}: {
+  alertName: string
+  readerCount: number
+  stories: Story[]
+  strategy: Strategy
+  wait: Wait
+}) => {
   return (
     <Html lang='en' dir='ltr'>
       <Preview>{stories[0]?.keyFindings?.join(' ') ?? ''}</Preview>
@@ -18,29 +34,43 @@ export const Alert = ({ stories }: { stories: Story[] }) => {
         <Body>
           <Container className='max-w-2xl mx-auto p-1 font-sans'>
             <Section>
-              {stories && stories.length > 0 ? (
-                <div>
-                  {stories.map((story) => (
-                    <div key={story.id}>
-                      <Link
-                        href={story.originalUrl}
-                        className='text-orange-500 no-underline'
-                      >
-                        <Heading as='h2' className='text-lg font-semibold'>
-                          {story.title}
-                        </Heading>
-                      </Link>
-                      {story.keyFindings && story.keyFindings.length > 0 && (
-                        <ul className='text-gray-700 list-disc pl-4 leading-relaxed'>
-                          {story.keyFindings.map((finding) => (
-                            <li key={finding}>{finding}</li>
-                          ))}
-                        </ul>
-                      )}
-                    </div>
-                  ))}
+              <div className='flex flex-col gap-2'>
+                <div className='flex flex-col gap-1'>
+                  <Heading as='h1' className='text-xl font-bold'>
+                    {alertName}
+                  </Heading>
+                  <Text className='text-xs text-gray-500'>
+                    {strategy.provider} ·{' '}
+                    {wait.type === 'count'
+                      ? `after ${wait.value} stories`
+                      : wait.value}{' '}
+                    · {readerCount} readers
+                  </Text>
                 </div>
-              ) : null}
+                {stories && stories.length > 0 ? (
+                  <div className='flex flex-col gap-1'>
+                    {stories.map((story) => (
+                      <div key={story.id}>
+                        <Link
+                          href={story.originalUrl}
+                          className='text-orange-500 no-underline'
+                        >
+                          <Heading as='h2' className='text-lg font-semibold'>
+                            {story.title}
+                          </Heading>
+                        </Link>
+                        {story.keyFindings && story.keyFindings.length > 0 && (
+                          <ul className='text-gray-700 list-disc pl-4 leading-relaxed'>
+                            {story.keyFindings.map((finding) => (
+                              <li key={finding}>{finding}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
             </Section>
           </Container>
         </Body>
@@ -50,6 +80,8 @@ export const Alert = ({ stories }: { stories: Story[] }) => {
 }
 
 Alert.PreviewProps = {
+  alertName: 'Tech Digest',
+  readerCount: 123,
   stories: [
     {
       alertId: '6JTQMD8N8BMD',
@@ -83,4 +115,9 @@ Alert.PreviewProps = {
       url: 'https://simonwillison.net/2025/May/27/llm-tools',
     },
   ],
+  strategy: {
+    provider: 'google',
+    query: 'latest tech news',
+  },
+  wait: { type: 'schedule', value: '0 0 * * *' },
 }


### PR DESCRIPTION
## Summary
- include newsletter name, strategy, frequency and readers in alert email
- pass newsletter metadata through herald
- compute reader count during alert processing

## Testing
- `bun run style:check`
- `bun run tidy` *(fails: fetch ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68567843e7388329aca1aa9ab6736b41