### PR TITLE
Fix subscription count for deleted alerts

### DIFF
--- a/app/my/layout.tsx
+++ b/app/my/layout.tsx
@@ -58,10 +58,12 @@ const MyLayout = async ({ children }: { children: React.ReactNode }) => {
         ? db
             .select({ count: count() })
             .from(subscriptions)
+            .innerJoin(alerts, eq(subscriptions.alertId, alerts.id))
             .where(
               and(
                 eq(subscriptions.userId, user.id),
                 isNull(subscriptions.deletedAt),
+                isNull(alerts.deletedAt),
               ),
             )
             .then((r) => r[0]?.count ?? 0)


### PR DESCRIPTION
## Summary
- exclude soft-deleted alerts when counting subscriptions in My workspace sidebar

## Testing
- `bun run tidy` *(fails: PLUNK_API_KEY is not set)*
- `bun run style:check`


------
https://chatgpt.com/codex/tasks/task_e_6857ffaf4a9c8329bc615cd886b2504c