### PR TITLE
Update fast channel messages

### DIFF
--- a/messengers/discord.ts
+++ b/messengers/discord.ts
@@ -27,7 +27,7 @@ export const sendDiscordAlert = async ({
   })
 
   try {
-    // Send each story URL as a separate message
+    // Send each story title and link as a separate message
     for (let i = 0; i < stories.length; i++) {
       const story = stories[i]
       const everynewsUrl = `${url}/stories/${story.id}`
@@ -50,7 +50,7 @@ export const sendDiscordAlert = async ({
         `https://discord.com/api/v10/channels/${channelId}/messages`,
         {
           body: JSON.stringify({
-            content: everynewsUrl,
+            content: `${story.title} ${everynewsUrl}`,
           }),
           headers: {
             Authorization: `Bot ${botToken}`,

--- a/messengers/slack.ts
+++ b/messengers/slack.ts
@@ -32,7 +32,7 @@ export const sendSlackAlert = async ({
   try {
     const slack = new WebClient(accessToken)
 
-    // Send each story URL as a separate message
+    // Send each story title and link as a separate message
     for (let i = 0; i < stories.length; i++) {
       const story = stories[i]
       const everynewsUrl = `${url}/stories/${story.id}`
@@ -53,7 +53,7 @@ export const sendSlackAlert = async ({
 
       const result = await slack.chat.postMessage({
         channel: channelId,
-        text: everynewsUrl,
+        text: `${story.title} ${everynewsUrl}`,
       })
 
       await track({

--- a/messengers/surge.ts
+++ b/messengers/surge.ts
@@ -144,8 +144,10 @@ export const sendSmsAlert = async ({
   }
 
   try {
-    // Format the alert messages (one URL per story)
-    const messageUrls = stories.map((story) => `${url}/stories/${story.id}`)
+    // Format the alert messages as "title link" (one per story)
+    const messageUrls = stories.map(
+      (story) => `${story.title} ${url}/stories/${story.id}`,
+    )
 
     // Get the Surge account ID from environment
     const accountId = process.env.SURGE_ACCOUNT_ID
@@ -153,7 +155,7 @@ export const sendSmsAlert = async ({
       throw new Error('SURGE_ACCOUNT_ID not configured')
     }
 
-    // Send each URL as a separate message
+    // Send each entry as a separate message
     for (let i = 0; i < messageUrls.length; i++) {
       const messageBody = messageUrls[i]
 


### PR DESCRIPTION
## Summary
- include story titles in fast channel messages

## Testing
- `bun run style:check`
- `bun run test`
- `bun run db:check`
- `bun run build` *(fails: Database connection string format for `neon()` should be: postgresql://user:password@host.tld/dbname?option=value)*

------
https://chatgpt.com/codex/tasks/task_e_6868be65c89c832985783c7a38acd886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert messages sent via Discord, Slack, and SMS now include both the story title and its link, providing more context in notifications.

* **Documentation**
  * Updated comments to accurately describe the new message content format in Discord, Slack, and SMS alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->