### PR TITLE
fix: Fast Channel Delivery Fix for Scheduled Alerts

### DIFF
--- a/app/my/alerts/[id]/alert-edit-page.tsx
+++ b/app/my/alerts/[id]/alert-edit-page.tsx
@@ -645,7 +645,9 @@ export const AlertEditPage = ({
                         <FormLabel>Schedule</FormLabel>
                         <div className='text-muted-foreground text-xs mb-2'>
                           Times shown in your local timezone (
-                          {getUserTimezone()})
+                          {getUserTimezone()}) This only applies to "slow"
+                          channels, like email. Fast channels, like Slack, will
+                          always send immediately on discovery.
                         </div>
                         <div className='grid grid-cols-2 gap-4 sm:gap-8'>
                           <div className='flex flex-col gap-2'>

--- a/app/my/alerts/create/alert-create-page.tsx
+++ b/app/my/alerts/create/alert-create-page.tsx
@@ -533,7 +533,9 @@ export const AlertCreatePage = ({
                         <FormLabel>Schedule</FormLabel>
                         <div className='text-muted-foreground text-xs mb-2'>
                           Times shown in your local timezone (
-                          {getUserTimezone()})
+                          {getUserTimezone()}) This only applies to "slow"
+                          channels, like email. Fast channels, like Slack, will
+                          always send immediately on discovery.
                         </div>
                         <div className='grid grid-cols-2 gap-8'>
                           <div className='flex flex-col gap-2'>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Schedule" description in alert creation and edit forms to clarify that scheduled timing applies only to slow channels (e.g., email), while fast channels (e.g., Slack) send alerts immediately.

* **Bug Fixes**
  * Improved the scheduling logic for alert notifications to ensure more accurate timing for slow channels and immediate delivery for fast channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->