### PR TITLE
Fix network fetch for WHOIS curator

### DIFF
--- a/subroutines/curators/whois.ts
+++ b/subroutines/curators/whois.ts
@@ -1,4 +1,5 @@
 import type { Alert } from '@everynews/schema'
+import { ProxyAgent } from 'undici'
 import type { Curator } from './type'
 
 interface DnsResponse {
@@ -43,15 +44,19 @@ export const WhoisCurator: Curator = async (
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 30000)
 
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY
+  const dispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined
+
   try {
     const dnsUrl = `https://dns.google/resolve?name=${encodeURIComponent(domain)}&type=A`
 
     const response = await fetch(dnsUrl, {
+      dispatcher,
       headers: {
         Accept: 'application/json',
       },
       signal: controller.signal,
-    })
+    } as RequestInit)
 
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
## Summary
- ensure WhoisCurator uses proxy settings when performing DNS lookups

## Testing
- `bun run tidy` *(fails: SLACK_CLIENT_ID is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68844e531f948329a24df12e67ac658a